### PR TITLE
Code review: fixing some typos in comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /res
 .vscode
+.project

--- a/constants.h
+++ b/constants.h
@@ -13,10 +13,10 @@
 #define OPTIMIZE_SSD1306                // Optimizations for SSD1366 displays
 
 #define FRAME_TIME          66.666666   // Desired time per frame in ms (66.666666 is ~15 fps)
-#define RES_DIVIDER         2           // Hgher values will result in lower horizontal resolution when rasterize and lower process and memory usage
+#define RES_DIVIDER         2           // Higher values will result in lower horizontal resolution when rasterize and lower process and memory usage
                                         // Lower will require more process and memory, but looks nicer
 #define Z_RES_DIVIDER       2           // Zbuffer resolution divider. We sacrifice resolution to save memory
-#define DISTANCE_MULTIPLIER 20          // Distances are stored as uint8_t, mutiplying the distance we can obtain more precision taking care
+#define DISTANCE_MULTIPLIER 20          // Distances are stored as uint8_t, multiplying the distance we can obtain more precision taking care
                                         // of keep numbers inside the type range. Max is 256 / MAX_RENDER_DEPTH
 #define MAX_RENDER_DEPTH    12
 #define MAX_SPRITE_DEPTH    8

--- a/display.h
+++ b/display.h
@@ -33,7 +33,7 @@ void drawChar(int8_t x, int8_t y, char ch);
 void drawText(int8_t x, int8_t y, char *txt, uint8_t space = 1);
 void drawText(int8_t x, int8_t y, const __FlashStringHelper txt, uint8_t space = 1);
 
-// Initalize screen. Following line is for OLED 128x64 connected by I2C
+// Initialize screen. Following line is for OLED 128x64 connected by I2C
 Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 
 // FPS control
@@ -193,7 +193,7 @@ void drawSprite(
   bool maskPixel;
 
   // Don't draw if the sprite is hidden by z buffer
-  // Not checked per pixer for performance reasons
+  // Not checked per pixel for performance reasons
   if (zbuffer[min(max(x, 0), ZBUFFER_SIZE - 1) / Z_RES_DIVIDER] < distance * DISTANCE_MULTIPLIER) {
     return;
   }

--- a/doom-nano.ino
+++ b/doom-nano.ino
@@ -113,7 +113,7 @@ void spawnFireball(double x, double y) {
   }
 
   UID uid = create_uid(E_FIREBALL, x, y);
-  // Remove if already exists, donÂ´t throw anything. Not the best, but shouldnÂ´t happen too often
+  // Remove if already exists, don't throw anything. Not the best, but shouldn't happen too often
   if (isSpawned(uid)) return;
 
   // Calculate direction. 32 angles
@@ -193,7 +193,7 @@ UID detectCollision(const uint8_t level[], Coords *pos, double relative_x, doubl
     Coords new_coords = { entity[i].pos.x - relative_x, entity[i].pos.y - relative_y };
     uint8_t distance = coords_distance(pos, &new_coords);
 
-    // Check distance and if it´s getting closer
+    // Check distance and if it's getting closer
     if (distance < ENEMY_COLLIDER_DIST && distance < entity[i].distance) {
       return entity[i].uid;
     }
@@ -623,7 +623,7 @@ void renderGun(uint8_t gun_pos, double amount_jogging) {
     display.drawBitmap(x + 6, y - 11, bmp_fire_bits, BMP_FIRE_WIDTH, BMP_FIRE_HEIGHT, 1);
   }
 
-  // DonÂ´t draw over the hud!
+  // Don't draw over the hud!
   uint8_t clip_height = max(0, min(y + BMP_GUN_HEIGHT, RENDER_HEIGHT) - y);
 
   // Draw the gun (black mask + actual sprite).


### PR DESCRIPTION
Nice work!

The code could be shrunk/optimized the following ways:
1. remove Serial
display.h:    Serial.println(F("SSD1306 allocation failed"));
doom-nano.ino:  Serial.begin(9600);
this would be the easiest way to gain more memory
2. move from Arduino IDE to plain AVR-GCC
2.1. include Adafruit_SSD1306.h directly into project
2.2. factor out Wire.h
2.3. transfer program to atmega328 with ISP, like ArduinoISP
this will free the space of the bootloader
3. remove floating points with fixed point math
3.1. sin/asin could use 255bytes lookup table
3.2. distance, speed, fps, pos, deltas, damage etc in fixed point math
3.3. maybe worth a try: faster division algorithm for fixed point math
3.4. not recommended: https://en.wikipedia.org/wiki/Fast_inverse_square_root
If all floats/doubles and divisions are wiped out this will save some memory